### PR TITLE
[ 🔍 Search ] 조회 데이터 패칭

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "web-vitals": "^2.1.0"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "export PORT=8080 && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/src/components/common/Hover.tsx
+++ b/src/components/common/Hover.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { EyeOff, Folder, ICClose, ICDropdown, ICGlass, ICOpenLink, ThumbsUp } from '../../asset/icon';
 import ImgHomePreview from '../../asset/image/previewImg.png';
-import Thumbnail from '../search/Thumbnail';
+import Thumbnail from '../Search/Thumbnail';
 
 const Hover = () => {
   const [projectClicked, setprojectClicked] = useState(false);

--- a/src/components/common/Hover.tsx
+++ b/src/components/common/Hover.tsx
@@ -2,8 +2,6 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 import { EyeOff, Folder, ICClose, ICDropdown, ICGlass, ICOpenLink, ThumbsUp } from '../../asset/icon';
-import ImgHomePreview from '../../asset/image/previewImg.png';
-import Thumbnail from '../Search/Thumbnail';
 
 const Hover = () => {
   const [projectClicked, setprojectClicked] = useState(false);
@@ -14,63 +12,29 @@ const Hover = () => {
 
   return (
     <>
-      {projectClicked && (
-        <StSimilarProjectWrapper>
-          <StLeft>
-            <div>
-              <p>다음과 유사</p>
-              <button type="button" onClick={handleProjectClick}>
-                <p>지우기</p>
-                <ICClose />
-              </button>
-            </div>
-            <img src={ImgHomePreview} alt="썸네일 이미지" />
-            <div>
-              <p>여러 소유자</p>
-              <ICDropdown fill="white" />
-            </div>
-            <div>
-              <ICOpenLink fill="${({ theme }) => theme.colors.behance_gray500}" />
-              <p>전체 프로젝트 보기</p>
-            </div>
-          </StLeft>
-          <hr />
-          <StRight>
-            <div></div>
-            {[1, 2, 3, 4, 5].map((_, idx) => (
-              <Thumbnail key={idx} profileImg="" name="Wedge Studio" recommandCount={129} visibleCount={129} />
-            ))}
-          </StRight>
-          <StHr>
-            <hr />
-            <hr />
-          </StHr>
-        </StSimilarProjectWrapper>
-      )}
-
-      <StContainer>
-        <StButton type="button" className="category">
+      <StHoverContainer>
+        <button type="button" className="category">
           산업디자인
-        </StButton>
-        <StButton type="button" className="eyeOffButton">
+        </button>
+        <button type="button" className="eyeOffButton">
           <EyeOff />
-        </StButton>
+        </button>
         <p>KID CAM</p>
         <footer>
-          <StButton type="button" className="icGlass" onClick={handleProjectClick}>
+          <button type="button" className="icGlass" onClick={handleProjectClick}>
             <Glass />
             <p>유사프로젝트</p>
-          </StButton>
-          <StButton type="button" className="folder">
+          </button>
+          <button type="button" className="folder">
             <Folder />
             <p>저장</p>
-          </StButton>
-          <StButton type="button" className="thumbsup">
+          </button>
+          <button type="button" className="thumbsup">
             <ThumbsUp />
             <p>추천</p>
-          </StButton>
+          </button>
         </footer>
-      </StContainer>
+      </StHoverContainer>
     </>
   );
 };
@@ -82,7 +46,7 @@ const Glass = styled(ICGlass)`
   margin-left: -0.25rem;
 `;
 
-const StContainer = styled.section`
+const StHoverContainer = styled.section`
   width: 21.25rem;
   height: 17.1875rem;
   margin-top: 2.5rem;
@@ -102,201 +66,67 @@ const StContainer = styled.section`
   & > footer {
     display: flex;
     margin-top: 1rem;
+
+    & > button {
+      padding: 0.5rem 0.8125rem 0.25rem 0.75rem;
+      border: 1px solid transparent;
+      ${({ theme }) => theme.fonts.behance_acumin_pro_regular_12};
+      color: ${({ theme }) => theme.colors.behance_white};
+      border-radius: 1.25rem;
+    }
+
+    & button.icGlass {
+      margin-left: 0.75rem;
+      display: flex;
+      text-align: center;
+
+      background-color: rgba(255, 255, 255, 0.3);
+      & > p {
+        margin-left: 0.25rem;
+        margin-top: -0.1rem;
+      }
+      & :hover {
+        cursor: pointer;
+      }
+    }
+    & button.folder {
+      margin-left: 5rem;
+      display: flex;
+
+      background-color: rgba(255, 255, 255, 0.3);
+      & > p {
+        margin-left: 0.25rem;
+        margin-top: -0.1rem;
+      }
+    }
+    & button.thumbsup {
+      margin-left: 0.5rem;
+      display: flex;
+
+      background-color: rgba(255, 255, 255, 0.3);
+      & > p {
+        margin-left: 0.25rem;
+        margin-top: -0.1rem;
+      }
+    }
   }
-`;
 
-const StButton = styled.button`
-  padding: 0.5rem 0.8125rem 0.25rem 0.75rem;
-  border: 1px solid transparent;
-  ${({ theme }) => theme.fonts.behance_acumin_pro_regular_12};
-  color: ${({ theme }) => theme.colors.behance_white};
-  border-radius: 1.25rem;
+  & > button {
+    padding: 0.5rem 0.8125rem 0.25rem 0.75rem;
+    border: 1px solid transparent;
+    ${({ theme }) => theme.fonts.behance_acumin_pro_regular_12};
+    color: ${({ theme }) => theme.colors.behance_white};
+    border-radius: 1.25rem;
+  }
 
-  & .category {
+  & button.category {
     background-color: rgba(255, 255, 255, 0.3);
     margin-left: 0.75rem;
     margin-top: 0.75rem;
     ${({ theme }) => theme.fonts.behance_acumin_pro_regular_14};
   }
-  & .eyeOffButton {
+  & button.eyeOffButton {
     margin-left: 11.6rem;
     background-color: rgba(255, 255, 255, 0.4);
-  }
-  & .icGlass {
-    margin-left: 0.75rem;
-    display: flex;
-    text-align: center;
-
-    background-color: rgba(255, 255, 255, 0.3);
-    & > p {
-      margin-left: 0.25rem;
-      margin-top: -0.1rem;
-    }
-    & :hover {
-      cursor: pointer;
-    }
-  }
-  & .folder {
-    margin-left: 5rem;
-    display: flex;
-
-    background-color: rgba(255, 255, 255, 0.3);
-    & > p {
-      margin-left: 0.25rem;
-      margin-top: -0.1rem;
-    }
-  }
-  & .thumbsup {
-    margin-left: 0.5rem;
-    display: flex;
-
-    background-color: rgba(255, 255, 255, 0.3);
-    & > p {
-      margin-left: 0.25rem;
-      margin-top: -0.1rem;
-    }
-  }
-`;
-
-const StSimilarProjectWrapper = styled.section`
-  display: flex;
-
-  position: absolute;
-  z-index: 3;
-
-  width: 120rem;
-  height: 35rem;
-  margin-left: -1.9rem;
-  margin-bottom: 35rem;
-
-  background-color: ${({ theme }) => theme.colors.behance_black};
-
-  & > hr {
-    width: 0.0625rem;
-    height: 25rem;
-
-    margin-top: 3rem;
-    margin-left: 2.3125rem;
-
-    flex-grow: 0;
-    transform: rotate(-180deg);
-
-    background-color: ${({ theme }) => theme.colors.behance_gray500};
-  }
-`;
-
-const StLeft = styled.article`
-  width: 18.75rem;
-  height: 25rem;
-  margin: 3rem 0 0 1.875rem;
-
-  color: ${({ theme }) => theme.colors.behance_white};
-
-  & > img {
-    width: 18.75rem;
-    height: 12.5rem;
-  }
-
-  & > div:nth-child(1) {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-
-    margin-bottom: 1.5rem;
-
-    ${({ theme }) => theme.fonts.behance_acumin_pro_bold_17};
-
-    & > button {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-
-      width: 6.125rem;
-      height: 2.25rem;
-
-      border: 1px solid transparent;
-      border-radius: 6.25rem;
-
-      ${({ theme }) => theme.fonts.behance_acumin_pro_bold_14};
-      color: ${({ theme }) => theme.colors.behance_white};
-      background-color: ${({ theme }) => theme.colors.behance_gray700};
-
-      & > p {
-        margin-right: 0.5rem;
-      }
-    }
-  }
-
-  & > div:nth-child(3) {
-    display: flex;
-    align-items: center;
-
-    margin-top: 1.25rem;
-    ${({ theme }) => theme.fonts.behance_acumin_pro_bold_17};
-    & > p {
-      margin-right: 0.25rem;
-    }
-  }
-  & > div:nth-child(4) {
-    display: flex;
-    align-items: center;
-
-    margin-top: 5.1875rem;
-
-    ${({ theme }) => theme.fonts.behance_acumin_pro_bold_14};
-
-    & > p {
-      margin-left: 0.5rem;
-      color: ${({ theme }) => theme.colors.behance_gray500};
-    }
-  }
-`;
-
-const StRight = styled.div`
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-
-  margin: -9.625rem 0 0 1.5rem;
-  ${({ theme }) => theme.fonts.behance_acumin_pro_bold_16};
-  color: ${({ theme }) => theme.colors.behance_white};
-
-  & > div {
-    position: absolute;
-    z-index: 3;
-    float: right;
-
-    width: 9.375rem;
-    height: 24.25rem;
-    margin-top: 10rem;
-    margin-left: 87.625rem;
-
-    background-image: linear-gradient(to left, black, transparent);
-  }
-`;
-
-const StHr = styled.section`
-  display: flex;
-  justify-content: flex-start;
-
-  margin-top: 32.875rem;
-
-  position: absolute;
-  z-index: 2;
-
-  & > hr:nth-child(1) {
-    border: 1px solid;
-    background-color: ${({ theme }) => theme.colors.behance_blue};
-    position: absolute;
-    z-index: 2;
-    width: 30rem;
-    height: 0.125rem;
-    margin: 0;
-  }
-  & > hr:nth-child(2) {
-    border: 1px solid;
-    background-color: ${({ theme }) => theme.colors.behance_white};
-    width: 120rem;
-    height: 0.125rem;
-    margin: 0;
   }
 `;

--- a/src/components/common/SimilarProject.tsx
+++ b/src/components/common/SimilarProject.tsx
@@ -38,7 +38,7 @@ const SimilarProject = () => {
                 <ICClose />
               </button>
             </div>
-            <img src={ImgHomePreview} alt="썸네일 이미지" />
+            <img src={contentList[0].image} alt="썸네일 이미지" />
             <div>
               <p>여러 소유자</p>
               <ICDropdown fill="white" />

--- a/src/components/common/SimilarProject.tsx
+++ b/src/components/common/SimilarProject.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useState } from 'react';
+import styled from 'styled-components';
+
+import { ArrowRight, ICClose, ICDropdown, ICGlass, ICOpenLink, ThumbsUp } from '../../asset/icon';
+import ImgHomePreview from '../../asset/image/previewImg.png';
+import { ProjectData } from '../../types/project';
+import { getProject } from '../../utils/lib/project';
+import Thumbnail from '../Search/Thumbnail';
+
+const SimilarProject = () => {
+  const [projectClicked, setprojectClicked] = useState<boolean>(true);
+
+  const handleProjectClick = () => {
+    setprojectClicked((prev) => !prev);
+  };
+
+  const [contentList, setContentList] = useState<ProjectData[]>([]);
+
+  useEffect(() => {
+    const getContentList = async () => {
+      const { data } = await getProject();
+      const getProjectData = data.data as ProjectData[];
+      setContentList(getProjectData);
+    };
+
+    getContentList();
+  }, []);
+
+  return (
+    <>
+      {projectClicked && (
+        <StSimilarProjectWrapper>
+          <StLeft>
+            <div>
+              <p>다음과 유사</p>
+              <button type="button" onClick={handleProjectClick}>
+                <p>지우기</p>
+                <ICClose />
+              </button>
+            </div>
+            <img src={ImgHomePreview} alt="썸네일 이미지" />
+            <div>
+              <p>여러 소유자</p>
+              <ICDropdown fill="white" />
+            </div>
+            <div>
+              <ICOpenLink fill="${({ theme }) => theme.colors.behance_gray500}" />
+              <p>전체 프로젝트 보기</p>
+            </div>
+          </StLeft>
+          <hr />
+          <StRight>
+            <StIconWrapper>
+              <StArrowRight />
+            </StIconWrapper>
+            <div></div>
+            {contentList.map(({ id, writer, image, likeCount, viewCount }, idx) => (
+              <Thumbnail
+                key={idx}
+                previewData={{
+                  projectId: id,
+                  profileImg: image,
+                  name: writer,
+                  recommandCount: likeCount,
+                  visibleCount: viewCount,
+                }}
+              />
+            ))}
+          </StRight>
+          <StHr>
+            <hr />
+            <hr />
+          </StHr>
+        </StSimilarProjectWrapper>
+      )}
+    </>
+  );
+};
+
+export default SimilarProject;
+
+const StSimilarProjectWrapper = styled.section`
+  display: flex;
+
+  position: absolute;
+  z-index: 3;
+
+  width: 120rem;
+  height: 35rem;
+  margin-bottom: 35rem;
+
+  background-color: ${({ theme }) => theme.colors.behance_black};
+
+  & > hr {
+    width: 0.0625rem;
+    height: 25rem;
+
+    margin-top: 3rem;
+    margin-left: 2.3125rem;
+
+    flex-grow: 0;
+    transform: rotate(-180deg);
+
+    background-color: ${({ theme }) => theme.colors.behance_gray500};
+  }
+`;
+
+const StLeft = styled.article`
+  width: 18.75rem;
+  height: 25rem;
+  margin: 3rem 0 0 1.875rem;
+
+  color: ${({ theme }) => theme.colors.behance_white};
+
+  & > img {
+    width: 18.75rem;
+    height: 12.5rem;
+  }
+
+  & > div:nth-child(1) {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    margin-bottom: 1.5rem;
+
+    ${({ theme }) => theme.fonts.behance_acumin_pro_bold_17};
+
+    & > button {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+
+      width: 6.125rem;
+      height: 2.25rem;
+
+      border: 1px solid transparent;
+      border-radius: 6.25rem;
+
+      ${({ theme }) => theme.fonts.behance_acumin_pro_bold_14};
+      color: ${({ theme }) => theme.colors.behance_white};
+      background-color: ${({ theme }) => theme.colors.behance_gray700};
+
+      & > p {
+        margin-right: 0.5rem;
+      }
+    }
+  }
+
+  & > div:nth-child(3) {
+    display: flex;
+    align-items: center;
+
+    margin-top: 1.25rem;
+    ${({ theme }) => theme.fonts.behance_acumin_pro_bold_17};
+    & > p {
+      margin-right: 0.25rem;
+    }
+  }
+  & > div:nth-child(4) {
+    display: flex;
+    align-items: center;
+
+    margin-top: 5.1875rem;
+
+    ${({ theme }) => theme.fonts.behance_acumin_pro_bold_14};
+
+    & > p {
+      margin-left: 0.5rem;
+      color: ${({ theme }) => theme.colors.behance_gray500};
+    }
+  }
+`;
+
+const StRight = styled.div`
+  display: flex;
+
+  margin: -9.625rem 0 0 1.5rem;
+  ${({ theme }) => theme.fonts.behance_acumin_pro_bold_16};
+  color: ${({ theme }) => theme.colors.behance_white};
+
+  & > div {
+    position: absolute;
+    z-index: 3;
+    float: right;
+
+    width: 9.375rem;
+    height: 24.25rem;
+    margin-top: 10rem;
+    margin-left: 87.625rem;
+
+    background-image: linear-gradient(to left, black, transparent);
+  }
+`;
+
+const StIconWrapper = styled.section`
+  display: flex;
+  justify-content: space-between;
+
+  position: absolute;
+  z-index: 4;
+
+  width: 120rem;
+  height: 5.625rem;
+
+  margin: 15rem 0 0 91.375rem;
+`;
+
+const StArrowRight = styled(ArrowRight)`
+  /* padding: 14.0625rem 0 0 0rem; */
+`;
+
+const StHr = styled.section`
+  display: flex;
+  justify-content: flex-start;
+
+  margin-top: 32.875rem;
+
+  position: absolute;
+  z-index: 2;
+
+  & > hr:nth-child(1) {
+    border: 1px solid;
+    background-color: ${({ theme }) => theme.colors.behance_blue};
+    position: absolute;
+    z-index: 2;
+    width: 30rem;
+    height: 0.125rem;
+    margin: 0;
+  }
+  & > hr:nth-child(2) {
+    border: 1px solid;
+    background-color: ${({ theme }) => theme.colors.behance_white};
+    width: 120rem;
+    height: 0.125rem;
+    margin: 0;
+  }
+`;

--- a/src/components/search/ButtonModal.tsx
+++ b/src/components/search/ButtonModal.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import categoryImg from '../../asset/image/categoryImg.png';
 import { CategoryList } from '../../types/common';
 
-const Modal = () => {
+const ButtonModal = () => {
   const categorylist: CategoryList[] = [
     { id: 1, title: '최고의 Behance', color: '#2456f7', imgSrc: '#' },
     { id: 2, title: '그래픽 디자인', color: 'transparent', imgSrc: categoryImg },
@@ -29,11 +29,9 @@ const Modal = () => {
       <StModal>
         <p>최고의 크리에이티브 분야로 이루어진 갤러리</p>
         <div>
-
-          {categorylist.map(({ id, title, color, imgSrc }) => (
+          {categorylist.map(({ id, color, imgSrc, title }) => (
             <button type="button" key={id} style={{ backgroundColor: color, backgroundImage: `url(${imgSrc})` }}>
               {title}
-
             </button>
           ))}
         </div>
@@ -42,7 +40,7 @@ const Modal = () => {
   );
 };
 
-export default Modal;
+export default ButtonModal;
 
 const StModalWrapper = styled.section`
   display: flex;

--- a/src/components/search/HamburgerModal.tsx
+++ b/src/components/search/HamburgerModal.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import categoryImg from '../../asset/image/categoryImg.png';
 import { CategoryList } from '../../types/common';
 
-const Modal = () => {
+const HamburgerModal = () => {
   const categorylist: CategoryList[] = [
     { id: 1, title: '최고의 Behance', color: '#2456f7', imgSrc: '#' },
     { id: 2, title: '그래픽 디자인', color: 'transparent', imgSrc: categoryImg },
@@ -40,7 +40,7 @@ const Modal = () => {
   );
 };
 
-export default Modal;
+export default HamburgerModal;
 
 const StModalWrapper = styled.section`
   position: absolute;

--- a/src/components/search/Preview.tsx
+++ b/src/components/search/Preview.tsx
@@ -4,14 +4,24 @@ import styled from 'styled-components';
 import { ICRecommand, ICVisible } from '../../asset/icon';
 import ImgHomePreview from '../../asset/image/previewImg.png';
 import { ContentPreviewProps, PreviewData } from '../../types/common';
+import Hover from '../common/Hover';
 
 const Preview = (props: ContentPreviewProps) => {
   const { contentPreviewData, isHomePage } = props;
   const { projectId, profileImg, name, recommandCount, visibleCount } = contentPreviewData;
 
+  const [isHover, setIsHover] = useState(false);
+  const handleHover = () => {
+    setIsHover(true);
+  };
+  const handleHoverOut = () => {
+    setIsHover(false);
+  };
+
   return (
-    <StContentPreviewWrapper>
+    <StContentPreviewWrapper onMouseOver={handleHover} onMouseOut={handleHoverOut}>
       <img src={profileImg} alt="thumbnail" width={'21.25rem'} height={'17.1875rem'} />
+      {isHomePage && isHover && <Hover />}
       <StContentInfoWrapper>
         <p className="info_user">
           <img src={profileImg} alt="user_profile" />

--- a/src/components/search/Preview.tsx
+++ b/src/components/search/Preview.tsx
@@ -1,18 +1,20 @@
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { ICRecommand, ICVisible } from '../../asset/icon';
 import ImgHomePreview from '../../asset/image/previewImg.png';
-import { ContentPrviewData } from '../../types/common';
+import { ContentPreviewProps, PreviewData } from '../../types/common';
 
-const Preview = (props: ContentPrviewData) => {
-  const { profileImg, name, recommandCount, visibleCount } = props;
+const Preview = (props: ContentPreviewProps) => {
+  const { contentPreviewData, isHomePage } = props;
+  const { projectId, profileImg, name, recommandCount, visibleCount } = contentPreviewData;
 
   return (
     <StContentPreviewWrapper>
-      <img src={ImgHomePreview} alt="thumbnail" width={'21.25rem'} height={'17.1875rem'} />
+      <img src={profileImg} alt="thumbnail" width={'21.25rem'} height={'17.1875rem'} />
       <StContentInfoWrapper>
         <p className="info_user">
-          <img src={ImgHomePreview} alt="user_profile" />
+          <img src={profileImg} alt="user_profile" />
           <span>{name}</span>
         </p>
         <div className="reaction">

--- a/src/components/search/Preview.tsx
+++ b/src/components/search/Preview.tsx
@@ -2,9 +2,9 @@ import styled from 'styled-components';
 
 import { ICRecommand, ICVisible } from '../../asset/icon';
 import ImgHomePreview from '../../asset/image/previewImg.png';
-import { ContentPrivewData } from '../../types/common';
+import { ContentPrviewData } from '../../types/common';
 
-const Preview = (props: ContentPrivewData) => {
+const Preview = (props: ContentPrviewData) => {
   const { profileImg, name, recommandCount, visibleCount } = props;
 
   return (

--- a/src/components/search/Searchbar.tsx
+++ b/src/components/search/Searchbar.tsx
@@ -226,16 +226,14 @@ const StCategoryWrapper = styled.section`
 `;
 
 const StCategory = styled.article`
-  position: relative;
-
   margin-left: 2.0625rem;
-  margin-right: 4.375rem;
 `;
 
 const StCategoryButton = styled.button<{ categoryIsClicked: boolean }>`
   width: 7.8125rem;
   height: 3rem;
-  padding: 1rem 1.5rem 0.75rem 1.5rem;
+  /* padding: 1rem 1.5rem 0.75rem 1.5rem; */
+  padding: 1rem 0 1.5rem 0;
 
   border: 1px solid transparent;
   border-radius: 6.25rem;

--- a/src/components/search/Searchbar.tsx
+++ b/src/components/search/Searchbar.tsx
@@ -232,7 +232,6 @@ const StCategory = styled.article`
 const StCategoryButton = styled.button<{ categoryIsClicked: boolean }>`
   width: 7.8125rem;
   height: 3rem;
-  /* padding: 1rem 1.5rem 0.75rem 1.5rem; */
   padding: 1rem 0 1.5rem 0;
 
   border: 1px solid transparent;

--- a/src/components/search/SimilarProject.tsx
+++ b/src/components/search/SimilarProject.tsx
@@ -5,7 +5,7 @@ import { ArrowRight, ICClose, ICDropdown, ICGlass, ICOpenLink, ThumbsUp } from '
 import ImgHomePreview from '../../asset/image/previewImg.png';
 import { ProjectData } from '../../types/project';
 import { getProject } from '../../utils/lib/project';
-import Thumbnail from '../Search/Thumbnail';
+import Thumbnail from './Thumbnail';
 
 const SimilarProject = () => {
   const [projectClicked, setprojectClicked] = useState<boolean>(true);

--- a/src/components/search/SimilarProject.tsx
+++ b/src/components/search/SimilarProject.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { ArrowRight, ICClose, ICDropdown, ICGlass, ICOpenLink, ThumbsUp } from '../../asset/icon';
-import ImgHomePreview from '../../asset/image/previewImg.png';
 import { ProjectData } from '../../types/project';
 import { getProject } from '../../utils/lib/project';
 import Thumbnail from './Thumbnail';

--- a/src/components/search/Thumbnail.tsx
+++ b/src/components/search/Thumbnail.tsx
@@ -1,18 +1,18 @@
 import styled from 'styled-components';
 
 import { ICRecommand, ICVisible } from '../../asset/icon';
-import ImgHomePreview from '../../asset/image/previewImg.png';
-import { ContentPrviewData } from '../../types/common';
+import { ThumbnailProps } from '../../types/common';
 
-const Thumbnail = (props: ContentPrviewData) => {
-  const { profileImg, name, recommandCount, visibleCount } = props;
+const Thumbnail = (props: ThumbnailProps) => {
+  const { previewData } = props;
+  const { profileImg, name, recommandCount, visibleCount } = previewData;
 
   return (
     <StContentPreviewWrapper>
-      <img src={ImgHomePreview} alt="thumbnail" width={'21.25rem'} height={'17.1875rem'} />
+      <img src={profileImg} alt="thumbnail" width={'21.25rem'} height={'17.1875rem'} />
       <StContentInfoWrapper>
         <p className="info_user">
-          <img src={ImgHomePreview} alt="user_profile" />
+          <img src={profileImg} alt="user_profile" />
           <span>{name}</span>
         </p>
         <div className="reaction">
@@ -38,7 +38,7 @@ const StContentPreviewWrapper = styled.section`
   justify-content: center;
   align-items: center;
 
-  width: 21.25rem;
+  /* width: 21.25rem; */
   margin-top: 2.5rem;
   margin-right: 1.5rem;
 

--- a/src/components/search/Thumbnail.tsx
+++ b/src/components/search/Thumbnail.tsx
@@ -2,9 +2,9 @@ import styled from 'styled-components';
 
 import { ICRecommand, ICVisible } from '../../asset/icon';
 import ImgHomePreview from '../../asset/image/previewImg.png';
-import { ContentPrivewData } from '../../types/common';
+import { ContentPrviewData } from '../../types/common';
 
-const Thumbnail = (props: ContentPrivewData) => {
+const Thumbnail = (props: ContentPrviewData) => {
   const { profileImg, name, recommandCount, visibleCount } = props;
 
   return (

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import background from '../asset/image/searchHomeBackground.svg';
 import Hover from '../components/common/Hover';
 import Modal from '../components/common/Modal';
+import SimilarProject from '../components/common/SimilarProject';
 import {
   CategoryButton,
   HrContainer,
@@ -73,6 +74,7 @@ const Search = () => {
           />
         ))}
       </StContentSection>
+      <SimilarProject />
     </>
   );
 };

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -12,7 +12,9 @@ import {
   TitleBoard,
   TransparentHeader,
   WhiteHeader,
-} from '../components/search';
+} from '../components/Search';
+import { ProjectData } from '../types/project';
+import { getProject } from '../utils/lib/project';
 
 const Search = () => {
   const [isHover, setIsHover] = useState(false);
@@ -38,6 +40,18 @@ const Search = () => {
     setIsSpread(pageYOffset <= 450);
   };
 
+  const [contentList, setContentList] = useState<ProjectData[]>([]);
+
+  useEffect(() => {
+    const getContentList = async () => {
+      const { data } = await getProject();
+      const getProjectData = data.data as ProjectData[];
+      setContentList(getProjectData);
+    };
+
+    getContentList();
+  }, []);
+
   return (
     <>
       <StHeader>{!isSpread && <WhiteHeader />}</StHeader>
@@ -53,8 +67,18 @@ const Search = () => {
       <Searchbar />
 
       <StContentSection onMouseOver={handleHover} onMouseOut={handleHoverOut}>
-        {[1, 2, 3, 4, 5, 6, 6, 7, 7, 7, 7, 7, 7, 7, 2, 2, 2, , 2, , 2, 2, , 2].map((_, idx) => (
-          <Preview key={idx} profileImg="" name="Wedge Studio" recommandCount={129} visibleCount={129} />
+        {contentList.map(({ id, writer, image, likeCount, viewCount }, idx) => (
+          <Preview
+            key={idx}
+            isHomePage={true}
+            contentPreviewData={{
+              projectId: id,
+              profileImg: image,
+              name: writer,
+              recommandCount: likeCount,
+              visibleCount: viewCount,
+            }}
+          />
         ))}
         {isHover && <Hover />}
       </StContentSection>

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import background from '../asset/image/searchHomeBackground.svg';
 import Hover from '../components/common/Hover';
 import Modal from '../components/common/Modal';
-import SimilarProject from '../components/common/SimilarProject';
 import {
   CategoryButton,
   HrContainer,
@@ -14,6 +13,7 @@ import {
   TransparentHeader,
   WhiteHeader,
 } from '../components/Search';
+import SimilarProject from '../components/Search/SimilarProject';
 import { ProjectData } from '../types/project';
 import { getProject } from '../utils/lib/project';
 

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -17,14 +17,6 @@ import { ProjectData } from '../types/project';
 import { getProject } from '../utils/lib/project';
 
 const Search = () => {
-  const [isHover, setIsHover] = useState(false);
-  const handleHover = () => {
-    setIsHover(true);
-  };
-  const handleHoverOut = () => {
-    setIsHover(false);
-  };
-
   const [isSpread, setIsSpread] = useState<boolean>(true);
   const [pageY, setPageY] = useState(0);
   const documentRef = useRef(document);
@@ -66,7 +58,7 @@ const Search = () => {
 
       <Searchbar />
 
-      <StContentSection onMouseOver={handleHover} onMouseOut={handleHoverOut}>
+      <StContentSection>
         {contentList.map(({ id, writer, image, likeCount, viewCount }, idx) => (
           <Preview
             key={idx}
@@ -80,7 +72,6 @@ const Search = () => {
             }}
           />
         ))}
-        {isHover && <Hover />}
       </StContentSection>
     </>
   );

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -30,3 +30,7 @@ export interface ContentPreviewProps {
   contentPreviewData: PreviewData;
   isHomePage: boolean;
 }
+
+export interface ThumbnailProps {
+  previewData: PreviewData;
+}

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,4 +1,5 @@
-export interface ContentPrviewData {
+export interface PreviewData {
+  projectId: number;
   profileImg: string;
   name: string;
   recommandCount: number;
@@ -16,4 +17,16 @@ export interface DropboxList {
   id: number;
   title: string;
   src: string;
+}
+
+export interface ContentPrviewData {
+  profileImg: string;
+  name: string;
+  recommandCount: number;
+  visibleCount: number;
+}
+
+export interface ContentPreviewProps {
+  contentPreviewData: PreviewData;
+  isHomePage: boolean;
 }

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,0 +1,7 @@
+export interface ProjectData {
+  id: number;
+  writer: string;
+  image: string;
+  likeCount: number;
+  viewCount: number;
+}

--- a/src/utils/lib/project.ts
+++ b/src/utils/lib/project.ts
@@ -1,0 +1,9 @@
+import { reqAPI } from '.';
+
+export const getProject = async () => {
+  return reqAPI.get(`/project`);
+};
+
+export const getProjectId = async (params: string) => {
+  return reqAPI.get(`/project/${params}`);
+};


### PR DESCRIPTION
## 🔥 Related Issues
- close #44 

## 💙 작업 내용
- [x] 게시글 조회 데이터 패칭
- [x] 유사 프로젝트 클릭시 나오는 썸네일 데이터 패칭

## ✅ PR Point
사실 거의 서히의 데이터 패칭 클론 코딩...
> # types>common.ts
공동으로 쓰던 인터페이스가 ContentPrviewData였는데, 요것이 수정되니까 이걸 사용한 파일들(ex. Home.tsx)에서 에러가 나더라고용! 홈 부분은 서히 부분이라 제 브랜치에서 고치면 안된다고 생각해서, 서히가 수정한 ContentPrviewData 인터페이스를 PreviewData라는 이름으로 가져와 사용했습니당

```ts
export interface PreviewData {
  projectId: number;
  profileImg: string;
  name: string;
  recommandCount: number;
  visibleCount: number;
}

export interface CategoryList {
  id: number;
  title: string;
  color: string;
  imgSrc: string;
}

export interface DropboxList {
  id: number;
  title: string;
  src: string;
}

export interface ContentPrviewData {
  profileImg: string;
  name: string;
  recommandCount: number;
  visibleCount: number;
}

export interface ContentPreviewProps {
  contentPreviewData: PreviewData;
  isHomePage: boolean;
}

export interface ThumbnailProps {
  previewData: PreviewData;
}

```

> components/pages/Search/SimilarProject.tsx
왼쪽 썸네일 이미지는 다음과 같이 하나만 패칭해왔어요! 
`<img src={contentList[0].image} alt="썸네일 이미지" />`

## 👀 스크린샷 / GIF / 링크
<img width="1440" alt="스크린샷 2022-11-23 오전 10 40 33" src="https://user-images.githubusercontent.com/76681519/203456764-d806ec6f-4096-4349-84a3-90ea9c08e104.png">

<img width="1440" alt="스크린샷 2022-11-23 오전 11 23 13" src="https://user-images.githubusercontent.com/76681519/203457958-80b7e571-6adc-4f24-a543-910e80b91f94.png">

